### PR TITLE
Update expo-updates to 0.14.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "18.0.0",
     "react-native": "0.69.6",
     "react-native-web": "~0.18.7",
-    "expo-updates": "~0.14.6",
+    "expo-updates": "~0.14.7",
     "typescript": "^4.6.3",
     "@types/react": "~18.0.0",
     "@types/react-native": "~0.69.1"


### PR DESCRIPTION
Some dependencies are incompatible with the installed expo version:
[2023-01-23 16:12:17]   expo-updates@0.14.6 - expected version: ~0.14.7
[2023-01-23 16:12:17] Your project may not work correctly until you install the correct versions of the packages.
[2023-01-23 16:12:17] Install individual packages by running npx expo install expo-updates@~0.14.7