### PR TITLE
Handle Chords within the lyric text

### DIFF
--- a/__tests__/utils/StringUtils.test.ts
+++ b/__tests__/utils/StringUtils.test.ts
@@ -13,6 +13,7 @@ test("Remove square bracket function test", () => {
     "There this line has  nothing"
   );
 
-  expect (removeSquareBrackets("[hi]] this will ignore ] [hi] non finished brackets]["))
-  .toBe("] this will ignore ]  non finished brackets]")
+  expect(removeSquareBrackets("[hi]] this will ignore ] [hi] non finished brackets][")).toBe(
+    "] this will ignore ]  non finished brackets]"
+  );
 });

--- a/components/LyricComponent.tsx
+++ b/components/LyricComponent.tsx
@@ -1,34 +1,51 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, ScrollView } from "react-native";
 import { SongWithLyrics } from "../models/SongsApiModels";
 import { lyricStyles } from "../styles/GlobalStyles";
-import { convertSongToLyricBlocks } from "../utils/LyricUtils";
+import { convertSongToLyricBlocks, expandChordMap } from "../utils/LyricUtils";
+import { isMobile } from "../utils/PlatformUtils";
 
 // Define the component props
 interface LyricComponentProps {
   songData: SongWithLyrics;
   removeDuplicates: boolean;
+  displayChords: boolean;
 }
 
-const LyricComponent: React.FC<LyricComponentProps> = ({ songData, removeDuplicates }) => {
+const LyricComponent: React.FC<LyricComponentProps> = ({ songData, removeDuplicates, displayChords }) => {
   const song = songData.song;
   const lyricBlocks = convertSongToLyricBlocks(songData, removeDuplicates);
 
-  return (
-    <View style={lyricStyles.container}>
+  const content = (
+    <>
       <Text style={lyricStyles.title}>{song.title}</Text>
       <Text style={lyricStyles.author}>by {song.author}</Text>
-      {lyricBlocks.map((lyric, index) => (
-        <View key={`View ${index}`}>
-          <Text key={`${index}:verseTitle`} style={lyricStyles.verseTitle}>
+      {lyricBlocks.map((lyric, lyricIndex) => (
+        <View key={`View ${lyricIndex}`}>
+          <Text key={`${lyricIndex}:verseTitle`} style={lyricStyles.verseTitle}>
             {lyric.verseTitle}
           </Text>
-          <Text key={`${index}:${lyric.verseShorthand}`} style={lyricStyles.lyrics}>
-            {lyric.lyrics}
-          </Text>
+          {lyric.lyrics.map((lineWithChords, lineIndex) => (
+            <View key={`View ${lyric.verseShorthand}:${lineIndex}`}>
+              {displayChords && lineWithChords.chords.length > 0 ? (
+                <Text key={`${lineIndex}:${lyric.verseShorthand}`} style={lyricStyles.chords}>
+                  {expandChordMap(lineWithChords)}
+                </Text>
+              ) : null}
+              <Text key={`${lyric.verseShorthand} Line ${lineIndex}`} style={lyricStyles.lyrics}>
+                {lineWithChords.line}
+              </Text>
+            </View>
+          ))}
         </View>
       ))}
-    </View>
+    </>
+  );
+
+  return isMobile() ? (
+    <ScrollView contentContainerStyle={lyricStyles.scrollViewContainer}>{content}</ScrollView>
+  ) : (
+    <View style={lyricStyles.container}>{content}</View>
   );
 };
 

--- a/models/LocalModels.ts
+++ b/models/LocalModels.ts
@@ -4,7 +4,19 @@
 export interface LyricBlock {
   verseShorthand: string;
   verseTitle: string;
-  lyrics: string;
+  lyrics: LineWithChords[];
 }
 
-// TODO: Design Lyrics With Chord Display
+/**
+ * Single line with chords object. Multiple of these create a verse.
+ */
+export interface LineWithChords {
+  line: string;
+  chords: ChordWithIndex[];
+}
+
+// Map of index of the string where the chord is to the chord string.
+export interface ChordWithIndex {
+  index: number;
+  text: string;
+}

--- a/screens/SongScreen.tsx
+++ b/screens/SongScreen.tsx
@@ -25,7 +25,12 @@ const SongScreen = ({ route }) => {
 
   return (
     <SafeAreaView style={globalStyles.container}>
-      {isLoading ? <ActivityIndicator /> : <LyricComponent songData={data} removeDuplicates={false}></LyricComponent>}
+      {isLoading ? (
+        <ActivityIndicator />
+      ) : (
+        // TODO: Make these configurable from user preferences.
+        <LyricComponent songData={data} removeDuplicates={false} displayChords={false}></LyricComponent>
+      )}
     </SafeAreaView>
   );
 };

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -52,6 +52,10 @@ export const lyricStyles = StyleSheet.create({
     padding: 16,
     backgroundColor: "#fff",
   },
+  scrollViewContainer: {
+    paddingVertical: 16,
+    paddingHorizontal: 4,
+  },
   title: {
     fontSize: 24,
     fontWeight: "bold",
@@ -65,12 +69,19 @@ export const lyricStyles = StyleSheet.create({
   lyrics: {
     fontSize: 16,
     lineHeight: 24,
-    marginBottom: 16,
+    marginBottom: 0,
     marginLeft: 20,
+  },
+  chords: {
+    fontSize: 16,
+    lineHeight: 16,
+    marginLeft: 20,
+    // fontWeight: "200",
   },
   verseTitle: {
     fontSize: 16,
     lineHeight: 24,
     fontWeight: "bold",
+    marginTop: 16,
   },
 });

--- a/utils/PlatformUtils.ts
+++ b/utils/PlatformUtils.ts
@@ -1,0 +1,5 @@
+import { Platform } from "react-native";
+
+export function isMobile(): boolean {
+    return Platform.OS === 'android' || Platform.OS === 'ios'
+}

--- a/utils/StringUtils.ts
+++ b/utils/StringUtils.ts
@@ -2,18 +2,21 @@
  * Util functions for strings.
  */
 
+const PUNCTUATION_REGEX = /[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]/g;
+const DOUBLE_SPACES_REGEX = /\s{2,}/g;
+
 /**
  * Removes special characters from the string.
  */
 export function removePunctuation(s: string): string {
-  return s.replace(/[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]/g, "");
+  return s.replace(PUNCTUATION_REGEX, "");
 }
 
 /**
  * Replaces occurences of 2 or more spaces with a single space.
  */
 export function removeDoubleSpaces(s: string): string {
-  return s.replace(/\s{2,}/g, " ");
+  return s.replace(DOUBLE_SPACES_REGEX, " ");
 }
 
 /**

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -1,0 +1,11 @@
+// Use to stringify Maps for testing.
+export function replacer(_key: any, value: any[]) {
+  if (value instanceof Map) {
+    return {
+      dataType: "Map",
+      value: Array.from(value.entries()), // or with spread: value: [...value]
+    };
+  } else {
+    return value;
+  }
+}


### PR DESCRIPTION
Add support for chords which are interwoven into the lyric text via square brackets, like this https://github.com/Church-Life-Apps/SongsV2/blob/main/models/TempApiObjects.ts#L42

The logic of this code is potentially a little jank so this will probably get a re-design later down the road.

Example of what this would look like:
<img width="1432" alt="Screen Shot 2023-04-15 at 7 47 41 PM" src="https://user-images.githubusercontent.com/8559293/232260086-784cc30c-f241-412a-aaaa-c01840a3ad65.png">

Mobile:
<img width="200" alt="Screen Shot 2023-04-15 at 7 47 41 PM" src="https://user-images.githubusercontent.com/8559293/232260105-42e18895-388b-4c8e-9a84-5261385fca57.png">

We can figure out getting chords into the actual lyric data in the database some other day.

This PR contains:
* Lyric utils to handle chord data and rendering
* Update to LyricComponent
* Tests
